### PR TITLE
Add v2 archive format support with CRC32 verification

### DIFF
--- a/components/icons/CopyIcon.js
+++ b/components/icons/CopyIcon.js
@@ -1,0 +1,7 @@
+export function CopyIcon() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-3 h-3 inline-block ml-1">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.75a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184" />
+        </svg>
+    );
+}

--- a/components/wpress-browser.js
+++ b/components/wpress-browser.js
@@ -181,7 +181,19 @@ export default class WPressBrowser extends React.Component {
         const crcField = decoder.decode(eofBytes.slice(CRC_START_OFFSET, CRC_START_OFFSET + CRC_LENGTH))
         const sizeField = decoder.decode(eofBytes.slice(EOF_SIZE_START, EOF_SIZE_START + EOF_SIZE_LENGTH)).replace(/\0/g, '')
         const isV1 = eofBytes.every(b => b === 0)
-        const isV2 = V2_CRC_REGEX.test(crcField) && sizeField.length > 0
+
+        // Strict v2 check: reconstruct expected EOF block and compare byte-for-byte
+        let isV2 = false
+        if (V2_CRC_REGEX.test(crcField) && sizeField.length > 0) {
+            const expected = new Uint8Array(HEADER_SIZE)
+            // Write size field (null-padded to 14 bytes) at offset 255
+            const sizeBytes = new TextEncoder().encode(sizeField)
+            expected.set(sizeBytes, EOF_SIZE_START)
+            // Write CRC field (8 bytes) at offset 4369
+            const crcBytes = new TextEncoder().encode(crcField)
+            expected.set(crcBytes, CRC_START_OFFSET)
+            isV2 = eofBytes.every((b, i) => b === expected[i])
+        }
 
         // EOF block is not empty but not a valid v2 format — corrupted file
         if (!isV1 && !isV2) {

--- a/components/wpress-browser.js
+++ b/components/wpress-browser.js
@@ -5,6 +5,7 @@ import { saveAs } from 'file-saver'
 import { Modal } from "./Modal";
 import { DownloadIcon } from "./icons/DownloadIcon";
 import { LoadingIcon } from "./icons/LoadingIcon";
+import { CopyIcon } from "./icons/CopyIcon";
 
 import {
     makeKeyFromPassword,
@@ -12,6 +13,7 @@ import {
     extractEncryptedText,
     decrypt,
     decryptFile,
+    computeCrc32,
 } from "../helpers/cryptoHelpers";
 
 const NAME_START_OFFSET= 0
@@ -21,7 +23,12 @@ const SIZE_END_BYTE = 269
 const MTIME_START_BYTE = 269
 const MTIME_END_BYTE = 281
 const PREFIX_START_OFFSET= 281
-const PREFIX_LENGTH = 4096
+const PREFIX_LENGTH_V1 = 4096
+const PREFIX_LENGTH_V2 = 4088
+const CRC_START_OFFSET = 4369
+const CRC_LENGTH = 8
+const HEADER_SIZE = 4377
+const V2_EOF_PREFIX = '--AI1WM.'
 
 function formatBytes(bytes, decimals = 2) {
     if (bytes === 0) return '0 Bytes';
@@ -96,6 +103,8 @@ export default class WPressBrowser extends React.Component {
             isCompressed        : false,
             compressionType     : null,
             compressionError    : null,
+            isV2                : false,
+            archiveCrcWarning   : null,
         }
 
     }
@@ -141,15 +150,52 @@ export default class WPressBrowser extends React.Component {
         }
 
         this.setState({
-          errorMessage    : null,
-          isDraggedOver   : false,
-          isDropped       : true,
-          isCorruptedFile : false,
-          file            : file,
-          originalFile    : file,
+          errorMessage      : null,
+          isDraggedOver     : false,
+          isDropped         : true,
+          isCorruptedFile   : false,
+          isV2              : false,
+          archiveCrcWarning : null,
+          file              : file,
+          originalFile      : file,
         })
 
-        this.readFile(file)
+        this.detectVersionAndReadFile(file)
+    }
+
+    async detectVersionAndReadFile(file) {
+        if (file.size < HEADER_SIZE) {
+            this.readFile(file)
+            return
+        }
+
+        // Read the last HEADER_SIZE bytes to check for v2 EOF block
+        const eofBlob = file.slice(file.size - HEADER_SIZE, file.size)
+        const eofBuffer = await eofBlob.arrayBuffer()
+        const eofBytes = new Uint8Array(eofBuffer)
+        const decoder = new TextDecoder('ascii')
+        const eofStart = decoder.decode(eofBytes.slice(0, 8))
+        const isV2 = eofStart === V2_EOF_PREFIX
+
+        const stateUpdate = { isV2 }
+
+        if (isV2) {
+            // Extract expected CRC from EOF block: "--AI1WM.xxxxxxxx.EOF--"
+            const expectedCrc = decoder.decode(eofBytes.slice(8, 16))
+            const dataSize = file.size - HEADER_SIZE
+
+            if (dataSize > 0) {
+                const dataBlob = file.slice(0, dataSize)
+                const dataBuffer = await dataBlob.arrayBuffer()
+                const actualCrc = computeCrc32(new Uint8Array(dataBuffer))
+
+                if (actualCrc !== expectedCrc) {
+                    stateUpdate.archiveCrcWarning = `Archive CRC mismatch: expected ${expectedCrc}, got ${actualCrc}. Archive may be corrupted.`
+                }
+            }
+        }
+
+        this.setState(stateUpdate, () => this.readFile(file))
     }
 
     readPackageJson(file, size) {
@@ -176,26 +222,29 @@ export default class WPressBrowser extends React.Component {
             self.setState(stateUpdate);
         });
 
-        reader.readAsArrayBuffer(file.slice(4377, 4377 + size))
+        reader.readAsArrayBuffer(file.slice(HEADER_SIZE, HEADER_SIZE + size))
     }
 
     readFile(file) {
         this.setState({file: file})
 
-        if (file.size === 4377) {
+        if (file.size === HEADER_SIZE) {
             this.setState({isListing: true})
             return
         }
         let reader = new FileReader();
         reader.addEventListener("loadend", () => {
             let node = this.state.tree.root
-            let name, size, mtime, prefix
+            let name, size, mtime, prefix, crc
             try {
                 name = this.getName(reader.result)
                 size = parseInt(this.getSize(reader.result), 10)
                 mtime = this.getMTime(reader.result)
                 prefix = this.getPrefix(reader.result)
                 prefix = prefix === '.' ? '' : prefix
+                if (this.state.isV2) {
+                    crc = this.getCrc(reader.result)
+                }
             } catch (e) {
                 return this.setState({
                     isListing: true,
@@ -218,12 +267,16 @@ export default class WPressBrowser extends React.Component {
                 }
             }
 
-            node.files.push({name, size, content: file.slice(4377, 4377 + size)})
+            const fileEntry = {name, size, content: file.slice(HEADER_SIZE, HEADER_SIZE + size)}
+            if (crc) {
+                fileEntry.crc = crc
+            }
+            node.files.push(fileEntry)
             this.setState({tree: this.state.tree})
-            this.byteNumber += 4377 + size
-            this.readFile(file.slice(4377 + size, file.size))
+            this.byteNumber += HEADER_SIZE + size
+            this.readFile(file.slice(HEADER_SIZE + size, file.size))
         });
-        reader.readAsArrayBuffer(file.slice(0, 4377))
+        reader.readAsArrayBuffer(file.slice(0, HEADER_SIZE))
     }
 
     getName(blob) {
@@ -249,12 +302,18 @@ export default class WPressBrowser extends React.Component {
     }
 
     getPrefix(blob) {
-        let length = new Int8Array(blob, PREFIX_START_OFFSET, PREFIX_LENGTH).reduceRight((previous, current, index) => {
+        const prefixLength = this.state.isV2 ? PREFIX_LENGTH_V2 : PREFIX_LENGTH_V1
+        let length = new Int8Array(blob, PREFIX_START_OFFSET, prefixLength).reduceRight((previous, current, index) => {
             return previous ? previous : ((current === 0) ? false : index+1)
         }, false)
 
         let decoder = new TextDecoder('utf-8')
         return decoder.decode(new DataView(blob, PREFIX_START_OFFSET, length))
+    }
+
+    getCrc(blob) {
+        let decoder = new TextDecoder('utf-8')
+        return decoder.decode(new DataView(blob, CRC_START_OFFSET, CRC_LENGTH)).replace(/\0/g, '')
     }
 
     getContent(blob) {
@@ -354,6 +413,7 @@ export default class WPressBrowser extends React.Component {
                                     {loading === file.name && (
                                         <span className="ml-1 text-sm text-gray-500">Preparing download…</span>
                                     )}
+                                    {file.crc && <div className="ml-6 text-xs text-gray-400 font-mono cursor-pointer hover:text-gray-600 group/crc flex items-center" title="Click to copy" onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(file.crc); }}>CRC: {file.crc}<span className="invisible group-hover/crc:visible"><CopyIcon /></span></div>}
                                 </li>
                             </ul>
                         )
@@ -374,6 +434,8 @@ export default class WPressBrowser extends React.Component {
             errorMessage         : '',
             isPasswordRequested  : false,
             passwordError        : '',
+            isV2                 : false,
+            archiveCrcWarning    : null,
         });
     }
 
@@ -442,6 +504,15 @@ export default class WPressBrowser extends React.Component {
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
                         </svg>
                         This backup is corrupted!
+                    </div>
+                )
+            } else if (this.state.archiveCrcWarning) {
+                errorMessage = (
+                    <div className="bg-yellow-400 text-black text-center w-full rounded p-4 fixed top-0 left-0">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="mr-1 w-6 h-6 inline-block">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                        </svg>
+                        {this.state.archiveCrcWarning}
                     </div>
                 )
             } else if (this.state.compressionError) {

--- a/components/wpress-browser.js
+++ b/components/wpress-browser.js
@@ -28,7 +28,9 @@ const PREFIX_LENGTH_V2 = 4088
 const CRC_START_OFFSET = 4369
 const CRC_LENGTH = 8
 const HEADER_SIZE = 4377
-const V2_EOF_PREFIX = '--AI1WM.'
+const EOF_SIZE_START = 255
+const EOF_SIZE_LENGTH = 14
+const V2_CRC_REGEX = /^[0-9a-f]{8}$/i
 
 function formatBytes(bytes, decimals = 2) {
     if (bytes === 0) return '0 Bytes';
@@ -174,14 +176,23 @@ export default class WPressBrowser extends React.Component {
         const eofBuffer = await eofBlob.arrayBuffer()
         const eofBytes = new Uint8Array(eofBuffer)
         const decoder = new TextDecoder('ascii')
-        const eofStart = decoder.decode(eofBytes.slice(0, 8))
-        const isV2 = eofStart === V2_EOF_PREFIX
+
+        // v2 EOF: a255(null) + a14(size) + a4100(null) + a8(crc)
+        const crcField = decoder.decode(eofBytes.slice(CRC_START_OFFSET, CRC_START_OFFSET + CRC_LENGTH))
+        const sizeField = decoder.decode(eofBytes.slice(EOF_SIZE_START, EOF_SIZE_START + EOF_SIZE_LENGTH)).replace(/\0/g, '')
+        const isV1 = eofBytes.every(b => b === 0)
+        const isV2 = V2_CRC_REGEX.test(crcField) && sizeField.length > 0
+
+        // EOF block is not empty but not a valid v2 format — corrupted file
+        if (!isV1 && !isV2) {
+            this.setState({ archiveCrcWarning: true, isListing: true })
+            return
+        }
 
         const stateUpdate = { isV2 }
 
         if (isV2) {
-            // Extract expected CRC from EOF block: "--AI1WM.xxxxxxxx.EOF--"
-            const expectedCrc = decoder.decode(eofBytes.slice(8, 16))
+            const expectedCrc = crcField
             const dataSize = file.size - HEADER_SIZE
 
             if (dataSize > 0) {
@@ -190,7 +201,9 @@ export default class WPressBrowser extends React.Component {
                 const actualCrc = computeCrc32(new Uint8Array(dataBuffer))
 
                 if (actualCrc !== expectedCrc) {
-                    stateUpdate.archiveCrcWarning = `Archive CRC mismatch: expected ${expectedCrc}, got ${actualCrc}. Archive may be corrupted.`
+                    stateUpdate.archiveCrcWarning = true
+                    this.setState(stateUpdate)
+                    return
                 }
             }
         }
@@ -509,10 +522,10 @@ export default class WPressBrowser extends React.Component {
             } else if (this.state.archiveCrcWarning) {
                 errorMessage = (
                     <div className="bg-yellow-400 text-black text-center w-full rounded p-4 fixed top-0 left-0">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="mr-1 w-6 h-6 inline-block">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="mr-1 w-6 h-6 inline-block">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
                         </svg>
-                        {this.state.archiveCrcWarning}
+                        This backup file is damaged and can't be opened.<br />Try downloading or transferring the file again.<br /><br /><strong>Reason:</strong> File integrity check failed (CRC mismatch). <a href="https://help.servmask.com/knowledgebase/import-failed-crc-mismatch/" target="_blank" rel="noopener noreferrer" className="underline">Technical details</a>
                     </div>
                 )
             } else if (this.state.compressionError) {

--- a/helpers/cryptoHelpers.js
+++ b/helpers/cryptoHelpers.js
@@ -9,6 +9,32 @@ const CHUNK_SIZE_PREFIX_LENGTH = 4; // 4 bytes for compressed chunk size
 
 const CONFIG_FILES = ['package.json', 'multisite.json'];
 
+// CRC32b lookup table (polynomial 0xEDB88320)
+const CRC32_TABLE = (() => {
+    const table = new Uint32Array(256);
+    for (let i = 0; i < 256; i++) {
+        let crc = i;
+        for (let j = 0; j < 8; j++) {
+            crc = (crc & 1) ? (0xEDB88320 ^ (crc >>> 1)) : (crc >>> 1);
+        }
+        table[i] = crc;
+    }
+    return table;
+})();
+
+/**
+ * Computes CRC32b checksum of a Uint8Array
+ * @param {Uint8Array} uint8Array - Data to checksum
+ * @returns {string} 8-char lowercase hex CRC32
+ */
+export function computeCrc32(uint8Array) {
+    let crc = 0xFFFFFFFF;
+    for (let i = 0; i < uint8Array.length; i++) {
+        crc = CRC32_TABLE[(crc ^ uint8Array[i]) & 0xFF] ^ (crc >>> 8);
+    }
+    return ((crc ^ 0xFFFFFFFF) >>> 0).toString(16).padStart(8, '0');
+}
+
 export function isConfigFile(fileName) {
     return CONFIG_FILES.includes(fileName);
 }


### PR DESCRIPTION
- Detect v2 archives by checking EOF block for --AI1WM. prefix
- Parse path (4088 bytes) and CRC (8 bytes) fields conditionally
- Verify archive-level CRC on upload, show warning banner on mismatch
- Display per-file CRC below filename with click-to-copy
- Add computeCrc32 helper using CRC32b lookup table
- Add CopyIcon component